### PR TITLE
Manually build c++ code, do not rely on pip/setup.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ FROM rootproject/root:6.22.08-ubuntu20.04
 RUN apt-get update -qq && apt-get -y install python3-pip git
 
 ADD antares-backend /antares-backend
-RUN pip3 install -r /antares-backend/requirements.txt && \
+RUN cd /antares-backend/antares_src && \
+    g++ multiMessenger.cc -o multiMessenger `root-config --cflags --glibs` && \
+    cp multiMessenger ../antares_data_server/antares_bin/. && \
+    pip3 install -r /antares-backend/requirements.txt && \
     pip3 install -e /antares-backend[dataload]
 
 ADD config.yml /antares/config.yml

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ run: build
 		-v /tmp/dev/log:/var/log/containers \
 		-v /tmp/dev/antares-output:/antares/output \
 		--rm \
-		-p 8000:8000 \
+		-p 5002:8000 \
 		--name dev-oda-antares \
 		$(image) 
 


### PR DESCRIPTION
only *install* command of setuptools was redefined in the backend
But what command actually used is determined by pip, it is *develop* if pip called  with -e
And if *wheel* is in the environment, then  *bdist_wheel* actually called, not *install*
So to be sure the binary is rebuilt, I make it explicit. 
(It really drove me crazy till I had understood that my fixes to the cpp code not actually applied in a container.)

PS @volodymyrss please open write access to this repo